### PR TITLE
Ignore enum value case during deserialization

### DIFF
--- a/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
@@ -41,7 +41,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
 
             if (expectedType.IsEnum())
             {
-                value = Enum.Parse(expectedType, scalar.Value);
+                value = Enum.Parse(expectedType, scalar.Value, true);
             }
             else
             {


### PR DESCRIPTION
The enum value case is ignored by TypeConverter class (from Serialization/Utilities), but not by ScalarNodeDeserializer
